### PR TITLE
Add 'results/' directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,4 @@ data/*.json
 data/*
 
 output/
+results/


### PR DESCRIPTION
Exclude the 'results/' directory from version control to prevent unnecessary files from being tracked.