### PR TITLE
Rename and update freeze arguments in finetuning configuration

### DIFF
--- a/src/llavapool/hparams/finetuning_args.py
+++ b/src/llavapool/hparams/finetuning_args.py
@@ -338,7 +338,7 @@ class FinetuningArguments(FreezeArguments, LoraArguments, RLHFArguments, GaloreA
         default=True,
         metadata={"help": "Whether ot not to freeze vision tower in MLLM training."},
     )
-    train_mm_proj_only: bool = field(
+    freeze_language_model: bool = field(
         default=False,
         metadata={"help": "Whether or not to train the multimodal projector for MLLM only."},
     )
@@ -367,8 +367,6 @@ class FinetuningArguments(FreezeArguments, LoraArguments, RLHFArguments, GaloreA
         self.lora_target: List[str] = split_arg(self.lora_target)
         self.additional_target: Optional[List[str]] = split_arg(self.additional_target)
         self.galore_target: List[str] = split_arg(self.galore_target)
-        self.freeze_vision_tower = self.freeze_vision_tower or self.train_mm_proj_only
-        self.freeze_multi_modal_projector = self.freeze_multi_modal_projector and not self.train_mm_proj_only
         self.use_ref_model = self.stage == "dpo" and self.pref_loss not in ["orpo", "simpo"]
 
         assert self.finetuning_type in ["lora", "freeze", "full"], "Invalid fine-tuning method."
@@ -395,9 +393,6 @@ class FinetuningArguments(FreezeArguments, LoraArguments, RLHFArguments, GaloreA
 
         if self.pissa_init and (self.stage in ["ppo", "kto"] or self.use_ref_model):
             raise ValueError("Cannot use PiSSA for current training stage.")
-
-        if self.train_mm_proj_only and self.finetuning_type != "full":
-            raise ValueError("`train_mm_proj_only` is only valid for full training.")
 
         if self.finetuning_type != "lora":
             if self.loraplus_lr_ratio is not None:

--- a/src/llavapool/model/model_utils/visual.py
+++ b/src/llavapool/model/model_utils/visual.py
@@ -159,17 +159,17 @@ def get_forbidden_modules(config: "PretrainedConfig", finetuning_args: "Finetuni
     if model_type in COMPOSITE_MODELS:
         if finetuning_args.freeze_vision_tower:
             vision_model_keys = COMPOSITE_MODELS[model_type].vision_model_keys
-            logger.info(f"Set vision model not trainable: {vision_model_keys}.")
+            logger.info(f"\033[31mSet vision model not trainable: {vision_model_keys}.\033[0m")
             forbidden_modules.update(vision_model_keys)
 
         if finetuning_args.freeze_multi_modal_projector:
             projector_key = COMPOSITE_MODELS[model_type].projector_key
-            logger.info(f"Set multi model projector not trainable: {projector_key}.")
+            logger.info(f"\033[31mSet multi model projector not trainable: {projector_key}.\033[0m")
             forbidden_modules.add(projector_key)
-
-        if finetuning_args.train_mm_proj_only:
+        
+        if finetuning_args.freeze_language_model:
             language_model_keys = COMPOSITE_MODELS[model_type].language_model_keys
-            logger.info(f"Set language model not trainable: {language_model_keys}.")
+            logger.info(f"\033[31mSet language model not trainable: {language_model_keys}.\033[0m")
             forbidden_modules.update(language_model_keys)
 
     return forbidden_modules


### PR DESCRIPTION
Rename the `train_mm_proj_only` argument to `freeze_language_model` and adjust related logic in the finetuning configuration. Update logging messages to reflect these changes.